### PR TITLE
:bug: Resolved no password generated when count is at 1

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -20,7 +20,7 @@ fn main() {
 
     let mut passwords = Vec::new();
     
-    for _n in 1..args.count {
+    for _n in 0..args.count {
        passwords.push(password::generate_password(&config));
     }
 


### PR DESCRIPTION
Fixed a bug where the password is not generated when issuing the following commands:
- `passgen -LNS`
- `passgen -LNS --count 1`